### PR TITLE
Fix for Registration UX bug

### DIFF
--- a/PeepethClient/App/Base.lproj/Main.storyboard
+++ b/PeepethClient/App/Base.lproj/Main.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -69,7 +67,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="peepLogo" translatesAutoresizingMaskIntoConstraints="NO" id="flX-Hj-f63">
-                                <rect key="frame" x="173.66666666666666" y="294.66666666666669" width="66.666666666666657" height="67.333333333333314"/>
+                                <rect key="frame" x="173.33333333333334" y="294.66666666666669" width="67.333333333333343" height="67.333333333333314"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BOC-5D-HjN">
                                 <rect key="frame" x="82.666666666666671" y="518" width="248.66666666666663" height="40"/>
@@ -123,13 +121,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unofficial" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBr-iI-4lE">
-                                <rect key="frame" x="236.66666666666663" y="418" width="62" height="17"/>
+                                <rect key="frame" x="237" y="418" width="62" height="17"/>
                                 <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                 <color key="textColor" red="0.031372549019607843" green="0.031372549019607843" blue="0.031372549019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Client" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-KO-hEu">
-                                <rect key="frame" x="222.66666666666663" y="382" width="76" height="36"/>
+                                <rect key="frame" x="223" y="382" width="76" height="36"/>
                                 <fontDescription key="fontDescription" type="italicSystem" pointSize="30"/>
                                 <color key="textColor" red="0.031372549020000001" green="0.031372549020000001" blue="0.031372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -247,7 +245,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter password: MIN 5 chars" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2EJ-AC-Fvt">
-                                <rect key="frame" x="20.666666666666657" y="167" width="372.66666666666674" height="40"/>
+                                <rect key="frame" x="20.666666666666657" y="167.66666666666666" width="372.66666666666674" height="40"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <accessibility key="accessibilityConfiguration" identifier="WalletPasswordTextFieldPassphrase"/>
                                 <constraints>
@@ -293,7 +291,7 @@
                                 </connections>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Private Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eQq-3c-ixR">
-                                <rect key="frame" x="20.333333333333343" y="339.66666666666669" width="373" height="40"/>
+                                <rect key="frame" x="20.666666666666657" y="339.66666666666669" width="372.66666666666674" height="40"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <accessibility key="accessibilityConfiguration" identifier="WalletPasswordTextFieldPassphrase"/>
                                 <constraints>
@@ -306,7 +304,7 @@
                                 </connections>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Passwords don't match" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Xi-Bj-Of5">
-                                <rect key="frame" x="20.333333333333329" y="209.33333333333334" width="131.33333333333337" height="15"/>
+                                <rect key="frame" x="20.666666666666671" y="209.66666666666666" width="131.33333333333331" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="15" id="OhK-ak-dNQ"/>
                                 </constraints>
@@ -330,7 +328,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NRb-Hf-b6m">
-                                <rect key="frame" x="20.666666666666671" y="141" width="125.00000000000001" height="21"/>
+                                <rect key="frame" x="20.666666666666671" y="141.66666666666666" width="125.00000000000001" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -342,7 +340,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your private key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wsR-8J-jDA">
-                                <rect key="frame" x="20.333333333333329" y="312.66666666666669" width="176" height="22"/>
+                                <rect key="frame" x="20.666666666666671" y="312.66666666666669" width="176" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="GKI-Ar-5Tz"/>
                                 </constraints>
@@ -450,7 +448,7 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NickName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tz0-Wv-kbl">
-                                                    <rect key="frame" x="143" y="17.666666666666671" width="75" height="19.333333333333329"/>
+                                                    <rect key="frame" x="143" y="17" width="75" height="20.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -582,7 +580,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CcK-tx-fbh">
-                                <rect key="frame" x="20.666666666666657" y="415.66666666666669" width="372.66666666666674" height="40.333333333333314"/>
+                                <rect key="frame" x="20.666666666666657" y="415.66666666666669" width="372.66666666666674" height="40"/>
                                 <color key="backgroundColor" red="0.98431372549999996" green="0.4941176471" blue="0.20000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="18"/>
                                 <state key="normal" title="Logout">
@@ -658,13 +656,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Address successfully copied" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v74-tS-FJ9">
-                                <rect key="frame" x="98" y="527.66666666666663" width="218" height="21"/>
+                                <rect key="frame" x="98" y="527.33333333333337" width="218" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.40784313729999999" green="0.78039215689999997" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkbox_checked" translatesAutoresizingMaskIntoConstraints="NO" id="JbH-GP-Lfh">
-                                <rect key="frame" x="197" y="506" width="20" height="20"/>
+                                <rect key="frame" x="197" y="505.66666666666674" width="20" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="20" id="1d7-pa-MJX"/>
                                     <constraint firstAttribute="width" secondItem="JbH-GP-Lfh" secondAttribute="height" multiplier="1:1" id="LNm-ig-DmP"/>
@@ -778,7 +776,7 @@
                                 </state>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you choose &quot;Lock now&quot;, then message will also be posted to blockchain." lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pg2-Bq-FOE">
-                                <rect key="frame" x="41" y="353.66666666666669" width="206" height="26"/>
+                                <rect key="frame" x="40.666666666666657" y="353.66666666666669" width="206" height="26"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="26" id="RQ2-cJ-dv3"/>
                                     <constraint firstAttribute="width" constant="206" id="lGh-7O-NX1"/>
@@ -794,7 +792,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Be aware that it costs some gas" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vL6-Hr-Jez">
-                                <rect key="frame" x="41" y="379.66666666666669" width="153.33333333333334" height="12"/>
+                                <rect key="frame" x="40.666666666666671" y="379.66666666666669" width="153.33333333333331" height="12"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -878,7 +876,7 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NickName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xCy-Y8-y3r">
-                                                    <rect key="frame" x="143" y="17.666666666666671" width="75" height="19.333333333333329"/>
+                                                    <rect key="frame" x="143" y="17" width="75" height="20.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>

--- a/PeepethClient/App/Base.lproj/Main.storyboard
+++ b/PeepethClient/App/Base.lproj/Main.storyboard
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -67,7 +69,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="peepLogo" translatesAutoresizingMaskIntoConstraints="NO" id="flX-Hj-f63">
-                                <rect key="frame" x="173.33333333333334" y="294.66666666666669" width="67.333333333333343" height="67.333333333333314"/>
+                                <rect key="frame" x="173.66666666666666" y="294.66666666666669" width="66.666666666666657" height="67.333333333333314"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BOC-5D-HjN">
                                 <rect key="frame" x="82.666666666666671" y="518" width="248.66666666666663" height="40"/>
@@ -121,13 +123,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unofficial" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBr-iI-4lE">
-                                <rect key="frame" x="237" y="418" width="62" height="17"/>
+                                <rect key="frame" x="236.66666666666663" y="418" width="62" height="17"/>
                                 <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                 <color key="textColor" red="0.031372549019607843" green="0.031372549019607843" blue="0.031372549019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Client" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-KO-hEu">
-                                <rect key="frame" x="223" y="382" width="76" height="36"/>
+                                <rect key="frame" x="222.66666666666663" y="382" width="76" height="36"/>
                                 <fontDescription key="fontDescription" type="italicSystem" pointSize="30"/>
                                 <color key="textColor" red="0.031372549020000001" green="0.031372549020000001" blue="0.031372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -245,7 +247,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter password: MIN 5 chars" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2EJ-AC-Fvt">
-                                <rect key="frame" x="20.666666666666657" y="167.66666666666666" width="372.66666666666674" height="40"/>
+                                <rect key="frame" x="20.666666666666657" y="167" width="372.66666666666674" height="40"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <accessibility key="accessibilityConfiguration" identifier="WalletPasswordTextFieldPassphrase"/>
                                 <constraints>
@@ -291,7 +293,7 @@
                                 </connections>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Private Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eQq-3c-ixR">
-                                <rect key="frame" x="20.666666666666657" y="339.66666666666669" width="372.66666666666674" height="40"/>
+                                <rect key="frame" x="20.333333333333343" y="339.66666666666669" width="373" height="40"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <accessibility key="accessibilityConfiguration" identifier="WalletPasswordTextFieldPassphrase"/>
                                 <constraints>
@@ -304,7 +306,7 @@
                                 </connections>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Passwords don't match" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Xi-Bj-Of5">
-                                <rect key="frame" x="20.666666666666671" y="209.66666666666666" width="131.33333333333331" height="15"/>
+                                <rect key="frame" x="20.333333333333329" y="209.33333333333334" width="131.33333333333337" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="15" id="OhK-ak-dNQ"/>
                                 </constraints>
@@ -328,7 +330,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NRb-Hf-b6m">
-                                <rect key="frame" x="20.666666666666671" y="141.66666666666666" width="125.00000000000001" height="21"/>
+                                <rect key="frame" x="20.666666666666671" y="141" width="125.00000000000001" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -340,7 +342,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your private key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wsR-8J-jDA">
-                                <rect key="frame" x="20.666666666666671" y="312.66666666666669" width="176" height="22"/>
+                                <rect key="frame" x="20.333333333333329" y="312.66666666666669" width="176" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="GKI-Ar-5Tz"/>
                                 </constraints>
@@ -448,7 +450,7 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NickName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tz0-Wv-kbl">
-                                                    <rect key="frame" x="143" y="17" width="75" height="20.333333333333329"/>
+                                                    <rect key="frame" x="143" y="17.666666666666671" width="75" height="19.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -580,7 +582,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CcK-tx-fbh">
-                                <rect key="frame" x="20.666666666666657" y="415.66666666666669" width="372.66666666666674" height="40"/>
+                                <rect key="frame" x="20.666666666666657" y="415.66666666666669" width="372.66666666666674" height="40.333333333333314"/>
                                 <color key="backgroundColor" red="0.98431372549999996" green="0.4941176471" blue="0.20000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="18"/>
                                 <state key="normal" title="Logout">
@@ -656,13 +658,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Address successfully copied" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v74-tS-FJ9">
-                                <rect key="frame" x="98" y="527.33333333333337" width="218" height="21"/>
+                                <rect key="frame" x="98" y="527.66666666666663" width="218" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.40784313729999999" green="0.78039215689999997" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkbox_checked" translatesAutoresizingMaskIntoConstraints="NO" id="JbH-GP-Lfh">
-                                <rect key="frame" x="197" y="505.66666666666674" width="20" height="20"/>
+                                <rect key="frame" x="197" y="506" width="20" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="20" id="1d7-pa-MJX"/>
                                     <constraint firstAttribute="width" secondItem="JbH-GP-Lfh" secondAttribute="height" multiplier="1:1" id="LNm-ig-DmP"/>
@@ -776,7 +778,7 @@
                                 </state>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you choose &quot;Lock now&quot;, then message will also be posted to blockchain." lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pg2-Bq-FOE">
-                                <rect key="frame" x="40.666666666666657" y="353.66666666666669" width="206" height="26"/>
+                                <rect key="frame" x="41" y="353.66666666666669" width="206" height="26"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="26" id="RQ2-cJ-dv3"/>
                                     <constraint firstAttribute="width" constant="206" id="lGh-7O-NX1"/>
@@ -792,7 +794,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Be aware that it costs some gas" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vL6-Hr-Jez">
-                                <rect key="frame" x="40.666666666666671" y="379.66666666666669" width="153.33333333333331" height="12"/>
+                                <rect key="frame" x="41" y="379.66666666666669" width="153.33333333333334" height="12"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -876,7 +878,7 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NickName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xCy-Y8-y3r">
-                                                    <rect key="frame" x="143" y="17" width="75" height="20.333333333333329"/>
+                                                    <rect key="frame" x="143" y="17.666666666666671" width="75" height="19.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>

--- a/PeepethClient/ViewControllers/CreateWalletViewController.swift
+++ b/PeepethClient/ViewControllers/CreateWalletViewController.swift
@@ -181,8 +181,7 @@ extension CreateWalletViewController: UITextFieldDelegate {
             }
         case passwordTextField:
             if !futureString.isEmpty &&
-                futureString == repeatPasswordTextField.text ||
-                repeatPasswordTextField.text?.isEmpty == true {
+                futureString == repeatPasswordTextField.text {
                 passwordsDontMatch.isHidden = true
                 createButton.isEnabled = (!(enterPrivateKeyTextField.text?.isEmpty ?? true) || mode == .createKey)
             } else {

--- a/PeepethClient/ViewControllers/CreateWalletViewController.swift
+++ b/PeepethClient/ViewControllers/CreateWalletViewController.swift
@@ -181,7 +181,8 @@ extension CreateWalletViewController: UITextFieldDelegate {
             }
         case passwordTextField:
             if !futureString.isEmpty &&
-                futureString == repeatPasswordTextField.text {
+                futureString == repeatPasswordTextField.text ||
+                repeatPasswordTextField.text?.isEmpty == true {
                 passwordsDontMatch.isHidden = true
                 createButton.isEnabled = (!(enterPrivateKeyTextField.text?.isEmpty ?? true) || mode == .createKey)
             } else {


### PR DESCRIPTION
### Reference Ticket

<!-- Link to the GitHub Issue -->
https://github.com/matterinc/PeepethClient/issues/5

### Description

<!-- A brief description of what is changing and why. -->
Fix for Registration UX bug. When user types in a password, the "Passwords don't match" label shows up because the `textField:shouldChangeCharactersIn` function is matching the text with the `nil` text of the `repeatPasswordTextField`. This PR solves that issue simply by hiding the `passwordsDontMatch` label whenever `repeatPasswordTextField.text?.isEmpty`.

### Changes
<!-- Checklist of proposed changes. To mark a change as complete, put an 'x' in the box. -->
- [x] Adding extra check in `CreateWalletViewController` for when `repeatPasswordTextField` is empty.


### Review
<!-- Checklist of peers to review and test the code. Recommend including a due date. -->
- [ ] @BaldyAsh, code review, EOD 10/06
- [ ] @skywinder, code review, EOD 10/06


